### PR TITLE
[HOPSWORKS-596]  Refactor kagent registration and CSR request

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,11 +27,11 @@ default["kagent"]["enabled"]                       = "true"
 default["kagent"]["certs_dir"]                     = "#{node["kagent"]["dir"]}/host-certs"
 
 # API calls
-default["kagent"]["dashboard"]["api"]["register"]  = "ca/agentservice/register"
+default["kagent"]["dashboard"]["api"]["register"]  = "api/agentresource?action=register"
 default["kagent"]["dashboard"]["api"]["login"]     = "api/auth/login"
-default["kagent"]["dashboard"]["api"]["heartbeat"] = "api/agentresource/heartbeat"
+default["kagent"]["dashboard"]["api"]["ca_host"]   = "v2/certificate/host"
+default["kagent"]["dashboard"]["api"]["heartbeat"] = "api/agentresource?action=heartbeat"
 default["kagent"]["dashboard"]["api"]["alert"]     = "api/agentresource/alert"
-default["kagent"]["dashboard"]["api"]["rotate"]    = "ca/agentservice/rotate"
 
 # Username/Password for the dashboard connecting to Hopsworks
 default["kagent"]["dashboard"]["user"]             = "agent@hops.io"

--- a/files/default/kagent_utils/kagent_utils/kagent_config.py
+++ b/files/default/kagent_utils/kagent_utils/kagent_config.py
@@ -38,7 +38,7 @@ class KConfig:
             self._config.read(self._configFile)
             self.server_url = self._config.get('server', 'url')
             self.register_url = self.server_url + self._config.get('server', 'path-register')
-            self.rotate_url = self.server_url + self._config.get('server', 'path-rotate')
+            self.ca_host_url = self.server_url + self._config.get('server', 'path-ca-host')
             self.login_url = self.server_url + self._config.get('server', 'path-login')
             self.heartbeat_url = self.server_url + self._config.get('server', 'path-heartbeat')
             self.alert_url = self.server_url + self._config.get('server', 'path-alert')

--- a/files/default/kagent_utils/tests/test_kagent_config.py
+++ b/files/default/kagent_utils/tests/test_kagent_config.py
@@ -15,7 +15,7 @@ class TestKConfig(unittest.TestCase):
     url = 'http://localhost:1337/'
     path_login = 'login/path'
     path_register = 'register/path'
-    path_rotate = 'rotate/path'
+    path_ca_host = 'ca/host/path'
     path_heartbeat = 'heartbeat/path'
     path_alert = 'alert/path'
     username = 'username'
@@ -65,7 +65,7 @@ class TestKConfig(unittest.TestCase):
         self.assertEqual(self.url, config.server_url)
         self.assertEqual(self._toUrl(self.path_login), config.login_url)
         self.assertEqual(self._toUrl(self.path_register), config.register_url)
-        self.assertEqual(self._toUrl(self.path_rotate), config.rotate_url)
+        self.assertEqual(self._toUrl(self.path_ca_host), config.ca_host_url)
         self.assertEqual(self._toUrl(self.path_heartbeat), config.heartbeat_url)
         self.assertEqual(self._toUrl(self.path_alert), config.alert_url)
         self.assertEqual(self.username, config.server_username)
@@ -129,7 +129,7 @@ class TestKConfig(unittest.TestCase):
             'url': self.url,
             'path-login': self.path_login,
             'path-register': self.path_register,
-            'path-rotate': self.path_rotate,
+            'path-ca-host': self.path_ca_host,
             'path-heartbeat': self.path_heartbeat,
             'path-alert': self.path_alert,
             'username': self.username,

--- a/templates/default/config.ini.erb
+++ b/templates/default/config.ini.erb
@@ -1,9 +1,9 @@
 [server]
 url = <%= @rest_url %>
 path-login = <%= node[:kagent][:dashboard_app] %>/<%= node[:kagent][:dashboard][:api][:login] %>
-path-register = hopsworks-ca/<%= node[:kagent][:dashboard][:api][:register] %>
-path-rotate = hopsworks-ca/<%= node[:kagent][:dashboard][:api][:rotate] %>
+path-register = <%= node[:kagent][:dashboard_app] %>/<%= node[:kagent][:dashboard][:api][:register] %>
 path-heartbeat = <%= node[:kagent][:dashboard_app] %>/<%= node[:kagent][:dashboard][:api][:heartbeat] %>
+path-ca-host = <%= node[:kagent][:ca_app] %>/<%= node[:kagent][:dashboard][:api][:ca_host] %>
 path-alert = <%= node[:kagent][:dashboard_app] %>/<%= node[:kagent][:dashboard][:api][:alert] %>
 username = <%= node[:kagent][:dashboard][:user] %>
 password = <%= node[:kagent][:dashboard][:password] %>


### PR DESCRIPTION
[HOPSWORKS-596]  Separate host registration from csr signing. Revoke previous certificate when registering

[HOPSWORKS-596]  Get rid of certificate rotation endpoint and command id from csr.py

[HOPSWORKS-596]  Fix agent to heartbeat to the new API

[HOPSWORKS-596]  Refactor kagent alerting API

Depends on https://github.com/logicalclocks/hopsworks/pull/16