### PR TITLE
[HOPSWORKS-1229] Set cwd before calling conda scripts

### DIFF
--- a/files/default/agent.py
+++ b/files/default/agent.py
@@ -403,7 +403,7 @@ class CondaCommandsHandler:
         msg=""
         try:
             self._log_conda_command(proj, op, proj, arg, -1, 'WORKING')
-            msg = subprocess.check_output(['sudo', script, user, op, proj, arg, offline, kconfig.hadoop_home, install_jupyter], stderr=subprocess.STDOUT)
+            msg = subprocess.check_output(['sudo', script, user, op, proj, arg, offline, kconfig.hadoop_home, install_jupyter], cwd=kconfig.conda_dir, stderr=subprocess.STDOUT)
             command['status'] = 'SUCCESS'
             command['arg'] = arg
             self._log_conda_command(proj, op, proj, arg, 0, 'SUCCESS')
@@ -443,7 +443,7 @@ class CondaCommandsHandler:
             command_str = "sudo {0} {1} {2} {3} {4} {5} {6} {7}".format(script, user, op, proj, channelUrl, installType, lib, version)
             logger.info("Executing libOp command {0}".format(command_str))
             self._log_conda_command(proj, op, lib, version, -1, 'WORKING')
-            msg = subprocess.check_output(['sudo', script, user, op, proj, channelUrl, installType, lib, version], stderr=subprocess.STDOUT)
+            msg = subprocess.check_output(['sudo', script, user, op, proj, channelUrl, installType, lib, version], cwd=kconfig.conda_dir, stderr=subprocess.STDOUT)
             logger.info("Lib op finished without error.")
             logger.info("{0}".format(msg))
             command['status'] = 'SUCCESS'
@@ -490,7 +490,7 @@ class SystemCommandsHandler:
         for env in to_be_removed:
             try:
                 script = os.path.join(kconfig.bin_dir, 'anaconda_env.sh')
-                subprocess.check_call(['sudo', script, exec_user, 'REMOVE', env, '', '', '', ''])
+                subprocess.check_call(['sudo', script, exec_user, 'REMOVE', env, '', '', '', ''], cwd=kconfig.conda_dir)
                 logger.info("Removed Anaconda environment {0}".format(env))
                 self._conda_envs_monitor_list.remove(env)
             except CalledProcessError as e:

--- a/files/default/kagent_utils/kagent_utils/conda_envs_watcher_action.py
+++ b/files/default/kagent_utils/kagent_utils/conda_envs_watcher_action.py
@@ -8,19 +8,23 @@ import json
 A WatcherAction to monitor Anaconda environments and add them
 to a CircularLinkedList
 """
+
+
 class CondaEnvsWatcherAction(watcher_action.WatcherAction):
     def __init__(self, monitor_list, kconfig):
         self.monitor_list = monitor_list
         self.kconfig = kconfig
         self.conda_bin = os.path.join(kconfig.conda_dir, 'bin', 'conda')
-        
+
         # System conda envs that should NOT be cleaned by GC
         self._blacklisted_envs = set()
         self._blacklisted_envs.add('anaconda')
-        self._blacklisted_envs.add(os.path.basename(os.path.normpath(kconfig.conda_dir)))
+        self._blacklisted_envs.add(os.path.basename(
+            os.path.normpath(kconfig.conda_dir)))
         # python27 python36 hops-system
-        [self._blacklisted_envs.add(p.strip()) for p in kconfig.conda_envs_blacklist.split(',')]
-        
+        [self._blacklisted_envs.add(p.strip())
+         for p in kconfig.conda_envs_blacklist.split(',')]
+
     def preAction(self, *args, **kwargs):
         pass
 
@@ -28,7 +32,8 @@ class CondaEnvsWatcherAction(watcher_action.WatcherAction):
         conda_envs = self._get_conda_envs()
         envs_json = json.loads(conda_envs)
         if not envs_json.has_key('envs'):
-            raise RuntimeError('envs key does not exist in Anaconda env list command output')
+            raise RuntimeError(
+                'envs key does not exist in Anaconda env list command output')
         envs_path = envs_json['envs']
         envs = [os.path.basename(os.path.normpath(i)) for i in envs_path]
         for e in envs:
@@ -39,4 +44,4 @@ class CondaEnvsWatcherAction(watcher_action.WatcherAction):
         pass
 
     def _get_conda_envs(self):
-        return subprocess.check_output([self.conda_bin, "env", "list", "--json"])
+        return subprocess.check_output([self.conda_bin, "env", "list", "--json"], cwd=self.kconfig.conda_dir)


### PR DESCRIPTION
Conda creates temporary directories in CWD. If not set the default is /.
Anaconda user cannot and should not be able to write in /