### PR TITLE
[HOPSWORKS-1617] resolve_hostname now uses ohai fqdn first, then dns, then etc-hosts

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -127,19 +127,25 @@ module Kagent
     def resolve_hostname(ip)
       require 'resolv'
       hostf = Resolv::Hosts.new
+      dns = Resolv::DNS.new
 
+      # Try and resolve the IP first using /etc/hosts, then using DNS
       begin
         hname = hostf.getname(ip)
       rescue
         begin
           hname = node['fqdn']
         rescue
-            raise "Cannot resolve the hostname for IP address: #{h}"
+          begin
+            hostname = dns.getname(ip)
+            hname = hostname.to_s
+          rescue
+            raise "Cannot resolve the hostname for IP address: #{ip}"
+          end
         end
       end
     end
       
-      # Try and resolve hostname first using DNS, then /etc/hosts
     
     def private_recipe_hostnames(cookbook, recipe)
       valid_recipe(cookbook,recipe)

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -127,23 +127,19 @@ module Kagent
     def resolve_hostname(ip)
       require 'resolv'
       hostf = Resolv::Hosts.new
-      dns = Resolv::DNS.new
 
-      # Try and resolve hostname first using DNS, then /etc/hosts
       begin
-        hname = node['fqdn']
+        hname = hostf.getname(ip)
       rescue
         begin
-          hname = dns.getname(h)
+          hname = node['fqdn']
         rescue
-          begin
-            hname = hostf.getname(h)
-          rescue
             raise "Cannot resolve the hostname for IP address: #{h}"
-          end
         end
       end
     end
+      
+      # Try and resolve hostname first using DNS, then /etc/hosts
     
     def private_recipe_hostnames(cookbook, recipe)
       valid_recipe(cookbook,recipe)

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -128,16 +128,21 @@ module Kagent
       require 'resolv'
       hostf = Resolv::Hosts.new
       dns = Resolv::DNS.new
-      # Try and resolve hostname first using /etc/hosts, then use DNS
+
+      # Try and resolve hostname first using DNS, then /etc/hosts
       begin
-        hostname = hostf.getname(ip)
+        hname = node['fqdn']
       rescue
         begin
-          hostname = dns.getname(ip)
+          hname = dns.getname(h)
         rescue
-          raise "Cannot resolve the hostname for IP address: #{ip}"
+          begin
+            hname = hostf.getname(h)
+          rescue
+            raise "Cannot resolve the hostname for IP address: #{h}"
+          end
         end
-      end      
+      end
     end
     
     def private_recipe_hostnames(cookbook, recipe)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -230,28 +230,6 @@ if node.attribute? "hopsworks"
   end
 end
 
-template "#{node["kagent"]["home"]}/bin/start-all-local-services.sh" do
-  source "start-all-local-services.sh.erb"
-  owner node["kagent"]["user"]
-  group node["kagent"]["group"]
-  mode 0740
-end
-
-
-template "#{node["kagent"]["home"]}/bin/shutdown-all-local-services.sh" do
-  source "shutdown-all-local-services.sh.erb"
-  owner node["kagent"]["user"]
-  group node["kagent"]["group"]
-  mode 0740
-end
-
-template "#{node["kagent"]["home"]}/bin/status-all-local-services.sh" do
-  source "status-all-local-services.sh.erb"
-  owner node["kagent"]["user"]
-  group node["kagent"]["group"]
-  mode 0740
-end
-
 # Default to hostname found in /etc/hosts, but allow user to override it.
 # First with DNS. Highest priority if user supplies the actual hostname
 hostname = node['fqdn']

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -209,3 +209,27 @@ cookbook_file "#{node["kagent"]["certs_dir"]}/csr.py" do
   group node["kagent"]["certs_group"]
   mode 0710
 end
+
+
+template "#{node["kagent"]["home"]}/bin/start-all-local-services.sh" do
+  source "start-all-local-services.sh.erb"
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
+  mode 0740
+end
+
+
+template "#{node["kagent"]["home"]}/bin/shutdown-all-local-services.sh" do
+  source "shutdown-all-local-services.sh.erb"
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
+  mode 0740
+end
+
+template "#{node["kagent"]["home"]}/bin/status-all-local-services.sh" do
+  source "status-all-local-services.sh.erb"
+  owner node["kagent"]["user"]
+  group node["kagent"]["group"]
+  mode 0740
+end
+


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1617