### PR TITLE
[HWORKS-779] We can't use consul_helper as it introduces a cyclic dependency

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -237,7 +237,7 @@ if node["kagent"]["enabled"].casecmp?("true")
 
   kagent_crypto_dir = x509_helper.get_crypto_dir(node['kagent']['user'])
   hops_ca_bundle = "#{kagent_crypto_dir}/#{x509_helper.get_hops_ca_bundle_name()}"
-  registry_domain = consul_helper.get_service_fqdn("registry")
+  registry_domain = "registry.service.#{consul_domain}"
 
   directory "/etc/docker/certs.d/#{registry_domain}:#{node['hops']['docker']['registry']['port']}" do
     owner 'root'


### PR DESCRIPTION


* [HWORKS-779] We can't use consul_helper as it introduces a cyclic dependency

* [HWORKS-779] Missing service

[HWORKS-779]: https://hopsworks.atlassian.net/browse/HWORKS-779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-779]: https://hopsworks.atlassian.net/browse/HWORKS-779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ